### PR TITLE
Boolean from cpp not compatible with f90 logical

### DIFF
--- a/src/ddpcm/ddcosmo.f90
+++ b/src/ddpcm/ddcosmo.f90
@@ -117,7 +117,8 @@ public ddinit
 public fdoga
 public fdoka
 public fdokb
-public itsolv
+public itsolv_direct
+public itsolv_adjoint
 public memfree
 
 contains
@@ -881,13 +882,125 @@ intmlp = ss
 return
 end function intmlp
 !
-subroutine itsolv(star,phi,psi,sigma,ene)
-use iso_c_binding
-logical(c_bool),                 intent(inout)    :: star
-!logical(1),                 intent(inout)    :: star
+subroutine itsolv_direct(phi,psi,sigma,ene)
 real(8), dimension(ncav),        intent(in)    :: phi
 real(8), dimension(nbasis,nsph), intent(in)    :: psi
 real(8),                         intent(inout) :: ene
+real(8), dimension(nbasis,nsph), intent(inout) :: sigma
+!
+! local arrays:
+!
+real(8), allocatable :: g(:,:), pot(:), sigold(:,:), vlm(:)
+!
+! scratch arrays:
+!
+real(8), allocatable :: basloc(:), vplm(:), vcos(:), vsin(:)
+real(8), allocatable :: delta(:), norm(:)
+!
+! diis arrays:
+!
+real(8), allocatable :: xdiis(:,:,:), ediis(:,:,:), bmat(:)
+!
+! local variables:
+!
+integer :: it, isph, nmat, lenb, c1, c2, cr
+real(8)  :: tol, drms, dmax, fep
+logical :: dodiis, first
+!
+integer, parameter :: nitmax=300
+real(8),  parameter :: ten=10.d0, tredis=1.0d-2
+!
+! initialize the timer:
+!
+call system_clock(count_rate=cr)
+call system_clock(count=c1)
+!
+! allocate local variables and set convergence parameters
+!
+fep = (eps-one)/eps
+tol = ten**(-iconv)
+allocate (g(ngrid,nsph),pot(ngrid),vlm(nbasis),sigold(nbasis,nsph))
+sigold = zero
+allocate (delta(nbasis),norm(nsph))
+allocate(vplm(nbasis),basloc(nbasis),vcos(lmax+1),vsin(lmax+1))
+memuse = memuse + ngrid*nsph + ngrid*nproc + 2*nbasis*nproc + nbasis*nsph + &
+         2*nbasis*nproc + 2*(lmax+1)*nproc + nsph
+memmax = max(memmax,memuse)
+!
+! set up diis:
+!
+dodiis = .false.
+nmat   = 1
+lenb   = ndiis + 1
+allocate (xdiis(nbasis,nsph,ndiis),ediis(nbasis,nsph,ndiis),bmat(lenb*lenb))
+memuse = memuse + 2*nbasis*nsph*ndiis + lenb*lenb
+memmax = max(memmax,memuse)
+!
+! solve the direct equations
+!
+!
+! build g:
+!
+call wghpot(phi,g)
+do it = 1, nitmax
+  first = it.eq.1
+  vlm   = zero
+!$omp parallel do default(shared) private(basloc,vcos,vsin,vplm) &
+!$omp private(isph,pot,vlm,delta) schedule(dynamic,10)
+  do isph = 1, nsph
+    call calcv(first,isph,g(:,isph),pot,sigold,basloc,vplm,vcos,vsin)
+    call intrhs(isph,pot,vlm)
+    call solve(isph,vlm,sigma(:,isph))
+    delta = sigma(:,isph) - sigold(:,isph)
+    call hsnorm(delta,norm(isph))
+  end do
+!$omp end parallel do
+  call rmsvec(nsph,norm,drms,dmax)
+  if (drms.le.tredis .and. ndiis.gt.0) dodiis = .true.
+  if (dodiis) then
+    xdiis(:,:,nmat) = sigma
+    ediis(:,:,nmat) = sigma - sigold
+    call diis(nbasis*nsph,nmat,xdiis,ediis,bmat,sigma)
+  end if
+  if (iprint.gt.1) then
+    ene = pt5*fep*sprod(nbasis*nsph,sigma,psi)
+    write(iout,1000) it, ene, drms, dmax
+  end if
+  if (drms.le.tol) goto 900
+  sigold = sigma
+end do
+write(iout,1020)
+stop
+900 continue
+ene = pt5*fep*sprod(nbasis*nsph,sigma,psi)
+!
+! free the memory:
+!
+if (iprint.gt.1) write(iout,*)
+deallocate (g,pot,vlm,sigold)
+deallocate (delta,norm)
+deallocate (vplm,basloc,vcos,vsin)
+deallocate (xdiis,ediis,bmat)
+memuse = memuse - ngrid*nsph - ngrid*nproc - 2*nbasis*nproc - nbasis*nsph - &
+         2*nbasis*nproc - 2*(lmax+1)*nproc - nsph
+memuse = memuse - 2*nbasis*nsph*ndiis - lenb*lenb
+!
+call system_clock(count=c2)
+if (iprint.gt.0) then
+  write(iout,1010) '', dble(c2-c1)/dble(cr)
+  write(iout,*)
+end if
+if (iprint.ge.3) then
+  call prtsph('solution to the ddcosmo equations:',nsph,0,sigma)
+end if
+1000 format(' energy at iteration ',i4,': ',f14.7,' error (rms,max):',2f14.7)
+1010 format(' the solution to the ddCOSMO ',a,'equations took ',f8.3,' seconds.')
+1020 format(' ddCOSMO did not converge! Aborting...')
+return
+end subroutine itsolv_direct
+!
+subroutine itsolv_adjoint(psi,sigma)
+real(8), dimension(nbasis,nsph), intent(in)    :: psi
 real(8), dimension(nbasis,nsph), intent(inout) :: sigma
 !
 ! local arrays:
@@ -907,7 +1020,7 @@ real(8), allocatable :: xdiis(:,:,:), ediis(:,:,:), bmat(:)
 !
 integer :: it, isph, nmat, lenb, ig, c1, c2, cr
 real(8)  :: tol, drms, dmax, fep
-logical :: dodiis, first, newstar
+logical :: dodiis, first
 !
 integer, parameter :: nitmax=300
 real(8),  parameter :: ten=10.d0, tredis=1.0d-2
@@ -919,22 +1032,16 @@ call system_clock(count=c1)
 !
 ! allocate local variables and set convergence parameters
 !
-!print *, phi
-!print *, psi
-!print *, sigma
-
-newstar = .FALSE.
-
 fep = (eps-one)/eps
 tol = ten**(-iconv)
 allocate (g(ngrid,nsph),pot(ngrid),vlm(nbasis),sigold(nbasis,nsph))
 sigold = zero
 allocate (delta(nbasis),norm(nsph))
 allocate(vplm(nbasis),basloc(nbasis),vcos(lmax+1),vsin(lmax+1))
-if (newstar) allocate(xi(ngrid,nsph))
+allocate(xi(ngrid,nsph))
 memuse = memuse + ngrid*nsph + ngrid*nproc + 2*nbasis*nproc + nbasis*nsph + &
          2*nbasis*nproc + 2*(lmax+1)*nproc + nsph
-if (newstar) memuse = memuse + nsph*ngrid
+memuse = memuse + nsph*ngrid
 memmax = max(memmax,memuse)
 !
 ! set up diis:
@@ -946,92 +1053,50 @@ allocate (xdiis(nbasis,nsph,ndiis),ediis(nbasis,nsph,ndiis),bmat(lenb*lenb))
 memuse = memuse + 2*nbasis*nsph*ndiis + lenb*lenb
 memmax = max(memmax,memuse)
 !
-! solve the direct equations
-!
-if (.not. newstar) then
-!
-! build g:
-!
-  call wghpot(phi,g)
-  do it = 1, nitmax
-    first = it.eq.1
-    vlm   = zero
-!$omp parallel do default(shared) private(basloc,vcos,vsin,vplm) &
-!$omp private(isph,pot,vlm,delta) schedule(dynamic,10)
-    do isph = 1, nsph
-      call calcv(first,isph,g(:,isph),pot,sigold,basloc,vplm,vcos,vsin)
-      call intrhs(isph,pot,vlm)
-      call solve(isph,vlm,sigma(:,isph))
-      delta = sigma(:,isph) - sigold(:,isph)
-      call hsnorm(delta,norm(isph))
-    end do
-!$omp end parallel do
-    call rmsvec(nsph,norm,drms,dmax)
-    if (drms.le.tredis .and. ndiis.gt.0) dodiis = .true.
-    if (dodiis) then
-      xdiis(:,:,nmat) = sigma
-      ediis(:,:,nmat) = sigma - sigold
-      call diis(nbasis*nsph,nmat,xdiis,ediis,bmat,sigma)
-    end if
-    if (iprint.gt.1) then
-      ene = pt5*fep*sprod(nbasis*nsph,sigma,psi)
-      write(iout,1000) it, ene, drms, dmax
-    end if
-    if (drms.le.tol) goto 900
-    sigold = sigma
-  end do
-  write(iout,1020)
-  stop
-900 continue
-  ene = pt5*fep*sprod(nbasis*nsph,sigma,psi)
-!
-else
-!
 ! solve the adjoint equations:
 !
-  do it = 1, nitmax
-    first = it.eq.1
-    if (.not. first) then
-      xi = zero
+do it = 1, nitmax
+  first = it.eq.1
+  if (.not. first) then
+    xi = zero
 !$omp parallel do default(shared) private(isph,ig)
-      do isph = 1, nsph
-        do ig = 1, ngrid
-          xi(ig,isph) = dot_product(sigold(:,isph),basis(:,ig))
-        end do
-      end do
-!$omp end parallel do
-    end if
-!$omp parallel do default(shared) private(basloc,vcos,vsin,vplm) &
-!$omp private(isph,vlm,delta) schedule(dynamic,10)
     do isph = 1, nsph
-      call adjrhs(first,isph,psi(:,isph),xi,vlm,basloc,vplm,vcos,vsin)
-      call solve(isph,vlm,sigma(:,isph))
-      delta = sigma(:,isph) - sigold(:,isph)
-      call hsnorm(delta,norm(isph))
+      do ig = 1, ngrid
+        xi(ig,isph) = dot_product(sigold(:,isph),basis(:,ig))
+      end do
     end do
 !$omp end parallel do
-    call rmsvec(nsph,norm,drms,dmax)
-    if (drms.le.tredis .and. ndiis.gt.0) dodiis = .true.
-    if (dodiis) then
-      xdiis(:,:,nmat) = sigma
-      ediis(:,:,nmat) = sigma - sigold
-      call diis(nbasis*nsph,nmat,xdiis,ediis,bmat,sigma)
-    end if
-    if (iprint.gt.1) then
-      write(iout,1000) it, zero, drms, dmax
-    end if
-    if (drms.le.tol) goto 910
-    sigold = sigma
+  end if
+!$omp parallel do default(shared) private(basloc,vcos,vsin,vplm) &
+!$omp private(isph,vlm,delta) schedule(dynamic,10)
+  do isph = 1, nsph
+    call adjrhs(first,isph,psi(:,isph),xi,vlm,basloc,vplm,vcos,vsin)
+    call solve(isph,vlm,sigma(:,isph))
+    delta = sigma(:,isph) - sigold(:,isph)
+    call hsnorm(delta,norm(isph))
   end do
-  write(iout,1020)
-  stop
+!$omp end parallel do
+  call rmsvec(nsph,norm,drms,dmax)
+  if (drms.le.tredis .and. ndiis.gt.0) dodiis = .true.
+  if (dodiis) then
+    xdiis(:,:,nmat) = sigma
+    ediis(:,:,nmat) = sigma - sigold
+    call diis(nbasis*nsph,nmat,xdiis,ediis,bmat,sigma)
+  end if
+  if (iprint.gt.1) then
+    write(iout,1000) it, zero, drms, dmax
+  end if
+  if (drms.le.tol) goto 910
+  sigold = sigma
+end do
+write(iout,1020)
+stop
 910 continue
-end if
 !
 ! free the memory:
 !
 if (iprint.gt.1) write(iout,*)
-if (newstar) deallocate(xi)
+deallocate(xi)
 deallocate (g,pot,vlm,sigold)
 deallocate (delta,norm)
 deallocate (vplm,basloc,vcos,vsin)
@@ -1042,25 +1107,17 @@ memuse = memuse - 2*nbasis*nsph*ndiis - lenb*lenb
 !
 call system_clock(count=c2)
 if (iprint.gt.0) then
-  if (newstar) then
-    write(iout,1010) 'adjoint ', dble(c2-c1)/dble(cr)
-  else
-    write(iout,1010) '', dble(c2-c1)/dble(cr)
-  end if
+  write(iout,1010) 'adjoint ', dble(c2-c1)/dble(cr)
   write(iout,*)
 end if
 if (iprint.ge.3) then
-  if (newstar) then
-    call prtsph('solution to the ddcosmo adjoint equations:',nsph,0,sigma)
-  else
-    call prtsph('solution to the ddcosmo equations:',nsph,0,sigma)
-  end if
+  call prtsph('solution to the ddcosmo adjoint equations:',nsph,0,sigma)
 end if
 1000 format(' energy at iteration ',i4,': ',f14.7,' error (rms,max):',2f14.7)
 1010 format(' the solution to the ddCOSMO ',a,'equations took ',f8.3,' seconds.')
 1020 format(' ddCOSMO did not converge! Aborting...')
 return
-end subroutine itsolv
+end subroutine itsolv_adjoint
 !
 subroutine wghpot(phi,g)
 !
@@ -1465,4 +1522,6 @@ end do
 return
 end subroutine fdoga
 !
+
+
 end module ddcosmo

--- a/src/solver/ddPCM.cpp
+++ b/src/solver/ddPCM.cpp
@@ -54,7 +54,7 @@ ddPCM::~ddPCM() { memfree(); }
         Eigen::Matrix<double, Eigen::Dynamic,Eigen::Dynamic> psi, sigma;
         psi.resize(nbasis, nspheres);
         sigma.resize(nbasis, nspheres);
-        itsolv(false, phi.data(), psi.data(), sigma.data(), & ene);
+        itsolv_direct(phi.data(), psi.data(), sigma.data(), & ene);
         return sigma;
     }
 

--- a/src/solver/ddPCM.hpp
+++ b/src/solver/ddPCM.hpp
@@ -50,7 +50,7 @@ public:
   ~ddPCM();
   Eigen::Matrix3Xd cavity() const { return cavity_; }
   Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> computeCharges(Eigen::VectorXd phi);  
-  //subroutine itsolv(star,phi,psi,sigma,ene)
+  //subroutine itsolv_direct(phi,psi,sigma,ene)
 
 private:
   Eigen::Matrix3Xd cavity_;
@@ -93,12 +93,11 @@ extern "C" void fdokb(int * isph,
                       double * vsin,
                       double * fx);
 
-#define itsolv FortranCInterface_MODULE(ddcosmo, itsolv, DDCOSMO, ITSOLV)
-extern "C" void itsolv(bool star,
-                       double * phi,
-                       double * psi,
-                       double * sigma,
-                       double * ene);
+#define itsolv_direct FortranCInterface_MODULE(ddcosmo, itsolv_direct, DDCOSMO, ITSOLV_DIRECT)
+extern "C" void itsolv_direct(double * phi,
+			      double * psi,
+			      double * sigma,
+			      double * ene);
 
 #define copy_cavity                                                                 \
   FortranCInterface_MODULE(ddcosmo, copy_cavity, DDCOSMO, COPY_CAVITY)


### PR DESCRIPTION
Divided the routine itsolv into two, one for star (adjoint) and one for .not. star (direct). Then we do not have to send boolean from cpp to fortran.

Did not have rights to push directly to robertodr/pcmsolver...


